### PR TITLE
V0.013_008

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,13 +1,22 @@
 Revision history for Perl module Data::IEEE754::Tools.
 
 v0.013 Development Version
-    - v0.013_008: CPAN Testers for a slew of errors for v0.013_006, so fix those
-        IN PROGRESS
-        + BUG: t\09-signbit: while verifying test coverage in v0.013_008, discovered
+    - v0.013_008: Devel::Cover showed SKIP was too aggressive in t\09 and t\10, so never tested 
+		negate in v0.013_007.
+        + FIXED BUG: t\09-signbit: while verifying test coverage in v0.013_008, discovered
           that signbit test was never testing negate, because the SKIP was too aggressive;
           once I de-aggressified the SKIP, finding more failures.
-        -> it looks like NEG_IND is not properly sign-changed to POS_IND, either... need to
-           investigate further on multiple systems
+        + it looks like NEG_IND is not properly sign-changed to POS_IND, either... need to
+          investigate further on multiple systems
+		+ Determined that it's pointless to keep trying to make CORE::abs() pass the tests.
+		  Rename Data::IEEE754::Tools::absolute() to ...::abs(), and stop testing the 
+		  CORE::abs().  Just make a note that exporting abs or :signbit will override the
+		  builtin behavior, and explain how to still access CORE::abs().
+		+ remove isCoreAbsWrongForNegNaN(), since apparently Perl itself is the culprit, not
+		  certain implementations.  (The auto-stringification of NaN was sometimes not 
+		  distinguishing the sign bits.)
+	    + t\10-copysign: switch to the to_hex_floatingpoint() for comparing abs($x) to abs($z),
+		  to avoid the same display bug that masked the CORE::abs() bug for 5.8.5 and 5.24.0.
     - v0.013_007: CPAN Testers for a slew of errors for v0.013_006, so fix those
         FIXED = <https://rt.cpan.org/Ticket/Display.html?id=117163>
         + BUG DESCRIPTION: in some configs, the 09-signbit and 10-copysign values have wrong sign

--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,13 @@
 Revision history for Perl module Data::IEEE754::Tools.
 
 v0.013 Development Version
+    - v0.013_008: CPAN Testers for a slew of errors for v0.013_006, so fix those
+        IN PROGRESS
+        + BUG: t\09-signbit: while verifying test coverage in v0.013_008, discovered
+          that signbit test was never testing negate, because the SKIP was too aggressive;
+          once I de-aggressified the SKIP, finding more failures.
+        -> it looks like NEG_IND is not properly sign-changed to POS_IND, either... need to
+           investigate further on multiple systems
     - v0.013_007: CPAN Testers for a slew of errors for v0.013_006, so fix those
         FIXED = <https://rt.cpan.org/Ticket/Display.html?id=117163>
         + BUG DESCRIPTION: in some configs, the 09-signbit and 10-copysign values have wrong sign

--- a/TODO
+++ b/TODO
@@ -1,10 +1,5 @@
 TODO
-    - BUG: t\09-signbit: while verifying test coverage in v0.013_008,
-        discovered that signbit test was never testing negate, because the SKIP was too aggressive;
-        once I de-aggressified the SKIP, finding more failures
-
-    - add the "is_xxxx", sign-copy, and other similar functions from IEEE754/Data::Float
-      <https://rt.cpan.org/Ticket/Display.html?id=116155>
+    - long-term: implement more functions from IEEE754-2007, especially
       + IEEE754 5.4.2 => 5.12
         <format>-convertFormat
         <format>-convertFromDecimalCharacter

--- a/TODO
+++ b/TODO
@@ -1,4 +1,8 @@
 TODO
+    - BUG: t\09-signbit: while verifying test coverage in v0.013_008,
+        discovered that signbit test was never testing negate, because the SKIP was too aggressive;
+        once I de-aggressified the SKIP, finding more failures
+
     - add the "is_xxxx", sign-copy, and other similar functions from IEEE754/Data::Float
       <https://rt.cpan.org/Ticket/Display.html?id=116155>
       + IEEE754 5.4.2 => 5.12

--- a/Tools.pm
+++ b/Tools.pm
@@ -5,7 +5,7 @@ use strict;
 use Carp;
 use Exporter 'import';  # just use the import() function, without the rest of the overhead of ISA
 
-use version 0.77; our $VERSION = version->declare('0.013_007');
+use version 0.77; our $VERSION = version->declare('0.013_008');
 
 =pod
 
@@ -672,7 +672,7 @@ sub isSignaling {
     my $exp = substr($h,0,3);
     my $frc = substr($h,3,13);
     my $qbit = (0x8 && hex(substr($h,3,1))) >> 3;   # 1: quiet, 0: signaling
-    return ($exp eq '7FF' || $exp eq 'FFF') && ($frc ne '0'x13)  && (!$qbit) || 0;
+    return ($exp eq '7FF' || $exp eq 'FFF') && ($frc ne '0'x13)  && (!$qbit) || 0;  # v0.013_007 = possible coverage bug: don't know whether it's the paren or non-paren, but the "LEFT=TRUE" condition of "OR 2 CONDITIONS" is never covered
 }
 
 =head4 isSignalingConvertedToQuiet()
@@ -685,7 +685,7 @@ function is meaningful in your implementation of perl.
 =cut
 
 sub isSignalingConvertedToQuiet {
-    !isSignaling( POS_SNAN_FIRST ) || 0
+    !isSignaling( POS_SNAN_FIRST ) || 0     # v0.013 coverage note: ignore Devel::Cover failures on this line
 }
 
 =head3 isCanonical( I<value> )
@@ -721,16 +721,16 @@ Returns the "class" of the I<value>:
 =cut
 
 sub class {
-    return 'signalingNaN'       if isSignaling($_[0]);
+    return 'signalingNaN'       if isSignaling($_[0]);      # v0.013 coverage note: ignore Devel::Cover failures on this line (won't return on systems that quiet SNaNs
     return 'quietNaN'           if isNaN($_[0]);
     return 'negativeInfinity'   if isInfinite($_[0])    && isSignMinus($_[0]);
     return 'negativeNormal'     if isNormal($_[0])      && isSignMinus($_[0]);
     return 'negativeSubnormal'  if isSubnormal($_[0])   && isSignMinus($_[0]);
     return 'negativeZero'       if isZero($_[0])        && isSignMinus($_[0]);
-    return 'positiveZero'       if isZero($_[0])        && !isSignMinus($_[0]);
-    return 'positiveSubnormal'  if isSubnormal($_[0])   && !isSignMinus($_[0]);
-    return 'positiveNormal'     if isNormal($_[0])      && !isSignMinus($_[0]);
-    return 'positiveInfinity'   if isInfinite($_[0])    && !isSignMinus($_[0]);
+    return 'positiveZero'       if isZero($_[0])        && !isSignMinus($_[0]);     # v0.013 coverage note: ignore Devel::Cover->CONDITION failure; alternate condition already returned above
+    return 'positiveSubnormal'  if isSubnormal($_[0])   && !isSignMinus($_[0]);     # v0.013 coverage note: ignore Devel::Cover->CONDITION failure; alternate condition already returned above
+    return 'positiveNormal'     if isNormal($_[0])      && !isSignMinus($_[0]);     # v0.013 coverage note: ignore Devel::Cover->CONDITION failure; alternate condition already returned above
+    return 'positiveInfinity'   if isInfinite($_[0])    && !isSignMinus($_[0]);     # v0.013 coverage note: no tests for FALSE because all conditions covered above
 }
 
 =head3 radix( I<value> )
@@ -819,7 +819,7 @@ signed zeroes, on infinities, and on NaNs.)
 
 =cut
 
-sub negate {
+sub negate {    # v0.013 coverage issue?  negate() never tested?
     my $b = binstr754_from_double(shift);                                               # convert to binary string
     my $s = 1 - substr $b, 0, 1;                                                        # toggle sign
     substr $b, 0, 1, $s;                                                                # replace sign
@@ -869,7 +869,7 @@ indicate whether you should rely on the C<CORE::abs()> function or not.
 =cut
 
 sub isCoreAbsWrongForNegNaN {
-    ( hexstr754_from_double(CORE::abs(NEG_QNAN_LAST)) ne hexstr754_from_double(CORE::abs(POS_QNAN_LAST)) ) || 0;
+    ( hexstr754_from_double(CORE::abs(NEG_QNAN_LAST)) ne hexstr754_from_double(CORE::abs(POS_QNAN_LAST)) ) || 0; # v0.013 coverage note: ignore coverage fails -- a system will either evaluate to TRUE or to FALSE, never both, so Devel::Cover will never pass both
 }
 
 =head3 copySign( I<x>, I<y> )

--- a/Tools.pm
+++ b/Tools.pm
@@ -117,6 +117,8 @@ a transition to v2.
 
 =item v0.013_003: C<nextafter()> renamed to C<nextAfter()>
 
+=item v0.013_008: C<absolute()> renamed to C<abs()>, and noted that perl's builtin can be accessed via C<CORE::abs()>
+
 =back
 
 =head1 EXPORTABLE FUNCTIONS AND VARIABLES
@@ -146,7 +148,7 @@ my  @EXPORT_CONST = qw(
 my @EXPORT_INFO = qw(isSignMinus isNormal isFinite isZero isSubnormal
     isInfinite isNaN isSignaling isSignalingConvertedToQuiet isCanonical
     class radix totalOrder totalOrderMag);
-my @EXPORT_SIGNBIT = qw(negate absolute isCoreAbsWrongForNegNaN copySign isSignMinus);
+my @EXPORT_SIGNBIT = qw(negate abs isCoreAbsWrongForNegNaN copySign isSignMinus);
 
 our @EXPORT_OK = (@EXPORT_FLOATING, @EXPORT_RAW754, @EXPORT_ULP, @EXPORT_CONST, @EXPORT_INFO, @EXPORT_SIGNBIT);
 our %EXPORT_TAGS = (
@@ -389,9 +391,9 @@ zeroes, infinities, a variety of signaling and quiet NAN values.
     POS_NORM_SMALLEST    # +0x1.0000000000000p-1022  # smallest positive value that allows for normal representation in 64bit floating-point
     POS_NORM_BIGGEST     # +0x1.fffffffffffffp+1023  # largest positive value that allows for normal representation in 64bit floating-point
     POS_INF              # +0x1.#INF000000000p+0000  # positive infinity: indicates that the answer is out of the range of a 64bit floating-point
-    POS_SNAN_FIRST       # +0x1.#SNAN00000000p+0000  # positive signaling NAN with "0x0000000000001" as the system-dependent information; note that many perl interpreters will internally convert this to a Quiet NaN (QNAN)
-    POS_SNAN_LAST        # +0x1.#SNAN00000000p+0000  # positive signaling NAN with "0x7FFFFFFFFFFFF" as the system-dependent information; note that many perl interpreters will internally convert this to a Quiet NaN (QNAN)
-    POS_IND              # +0x1.#QNAN00000000p+0000  # positive quiet NAN with "0x8000000000000" as the system-dependent information; some perl interpreters define the NEG_IND as an "indeterminate" value (IND), and it wouldn't surprise me if some also defined this positive version as "indeterminate" as well
+    POS_SNAN_FIRST       # +0x1.#SNAN00000000p+0000  # positive signaling NAN with "0x0000000000001" as the system-dependent information [*]
+    POS_SNAN_LAST        # +0x1.#SNAN00000000p+0000  # positive signaling NAN with "0x7FFFFFFFFFFFF" as the system-dependent information [*]
+    POS_IND              # +0x1.#QNAN00000000p+0000  # positive quiet NAN with "0x8000000000000" as the system-dependent information [%]
     POS_QNAN_FIRST       # +0x1.#QNAN00000000p+0000  # positive quiet NAN with "0x8000000000001" as the system-dependent information
     POS_QNAN_LAST        # +0x1.#QNAN00000000p+0000  # positive quiet NAN with "0xFFFFFFFFFFFFF" as the system-dependent information
 
@@ -401,11 +403,15 @@ zeroes, infinities, a variety of signaling and quiet NAN values.
     NEG_NORM_SMALLEST    # -0x1.0000000000000p-1022  # smallest negative value that allows for normal representation in 64bit floating-point
     NEG_NORM_BIGGEST     # -0x1.fffffffffffffp+1023  # largest negative value that allows for normal representation in 64bit floating-point
     NEG_INF              # -0x1.#INF000000000p+0000  # negative infinity: indicates that the answer is out of the range of a 64bit floating-point
-    NEG_SNAN_FIRST       # -0x1.#SNAN00000000p+0000  # negative signaling NAN with "0x0000000000001" as the system-dependent information; note that many perl interpreters will internally convert this to a Quiet NaN (QNAN)
-    NEG_SNAN_LAST        # -0x1.#SNAN00000000p+0000  # negative signaling NAN with "0x7FFFFFFFFFFFF" as the system-dependent information; note that many perl interpreters will internally convert this to a Quiet NaN (QNAN)
-    NEG_IND              # -0x1.#IND000000000p+0000  # negative quiet NAN with "0x8000000000000" as the system-dependent information; some perl interpreters define the NEG_IND as an "indeterminate" value (IND)
+    NEG_SNAN_FIRST       # -0x1.#SNAN00000000p+0000  # negative signaling NAN with "0x0000000000001" as the system-dependent information [*]
+    NEG_SNAN_LAST        # -0x1.#SNAN00000000p+0000  # negative signaling NAN with "0x7FFFFFFFFFFFF" as the system-dependent information [*]
+    NEG_IND              # -0x1.#IND000000000p+0000  # negative quiet NAN with "0x8000000000000" as the system-dependent information [%]
     NEG_QNAN_FIRST       # -0x1.#QNAN00000000p+0000  # negative quiet NAN with "0x8000000000001" as the system-dependent information
     NEG_QNAN_LAST        # -0x1.#QNAN00000000p+0000  # negative quiet NAN with "0xFFFFFFFFFFFFF" as the system-dependent information
+	
+	[*] note that many perl interpreters will internally convert Signalling NaN (SNAN) to Quiet NaN (QNAN)
+	[%] some perl interpreters define the zeroeth negative Quiet NaN, NEG_IND, as an "indeterminate" value (IND); 
+	    in a symmetrical world, they would also define the zeroeth positive Quiet NaN, POS_IND, as an "indeterminate" value (IND)
 
 =cut
 
@@ -826,50 +832,29 @@ sub negate {    # v0.013 coverage issue?  negate() never tested?
     return binstr754_to_double($b);                                                     # convert to floating-point
 }
 
-=head3 CORE::abs( I<value> )
-=head3 absolute( I<value> )
+=head3 abs( I<value> )
+
+Similar to the C<CORE::abs()> builtin function, C<abs()> is provided as a 
+module-based function to get the absolute value (magnitude) of a 64bit 
+floating-point number.
 
 The C<CORE::abs()> function behaves properly (per the IEEE 754 description)
-for all classes of I<value> under many implementations.  However,
-there are implementations which incorrectly return a negative NaN, when
-the specification requires that it return a positive NaN.
+for all classes of I<value>, except that many implementations do not correctly
+handle -NaN properly, outputting -NaN, which is in violation of the standard.  
+The C<Data::IEEE754::Tools::abs()> function correctly treats NaNs in the same
+way it treats numerical values, and clears the sign bit on the output.
 
-C<absolute()> is provided as a module-based alternative which correctly handles
-the absolute value of a signed NaN.
-
-The test suite runs the expected input/output pairs thru both C<CORE::abs()> and
-C<Data::IEEE754::Tools::absolute()>, but will skip the C<CORE::abs()> NaN's if
-C<isCoreAbsWrongForNegNaN()> returns TRUE, and will leave a message indicating
-that condition, and that you should use C<Data::IEEE754::Tools::absolute()> if
-the sign of your NaN is important to you.
+Please note that exporting C<abs()> or C<:signbit> from this module will
+"hide" the builtin C<abs()> function.  If you really need to use the builtin
+version (for example, you care more about execution speed than its ability to find
+the absolute value of a signed NaN), then you may call it as C<CORE::abs>.
 
 =cut
 
-sub absolute {
+sub abs {
     my $b = binstr754_from_double(shift);                                               # convert to binary string
     substr $b, 0, 1, '0';                                                               # replace sign
     return binstr754_to_double($b);                                                     # convert to floating-point
-}
-
-=head4 isCoreAbsWrongForNegNaN()
-
-Returns 1 if the builtin C<CORE::abs()> function gets the sign wrong
-for a signed NaN, else returns 0.
-
-Some Perl implementations do not properly handle signed NaN.  One place
-that it shows up is whether C<CORE::abs(NEG_SNAN_LAST)> is still negative,
-or whether it's properly converted to a positive NaN.
-
-If the sign of your NaN is important, then you can use
-C<isCoreAbsWrongForNegNaN()> to determine whether you should choose
-to use the builtin C<abs()> function, or whether you should switch to
-using this module's C<absolute()> function.  The C<make test> will also
-indicate whether you should rely on the C<CORE::abs()> function or not.
-
-=cut
-
-sub isCoreAbsWrongForNegNaN {
-    ( hexstr754_from_double(CORE::abs(NEG_QNAN_LAST)) ne hexstr754_from_double(CORE::abs(POS_QNAN_LAST)) ) || 0; # v0.013 coverage note: ignore coverage fails -- a system will either evaluate to TRUE or to FALSE, never both, so Devel::Cover will never pass both
 }
 
 =head3 copySign( I<x>, I<y> )

--- a/t/09-signbit.t
+++ b/t/09-signbit.t
@@ -2,7 +2,7 @@
 # Verifies the following functions:
 #   :signbit
 #       negate(v)
-#       absolute(v)
+#       abs(v)
 # Will require separate test procedure:
 #       copySign(v)
 ########################################################################
@@ -12,85 +12,45 @@ use strict;
 use Test::More;
 use Data::IEEE754::Tools qw/:raw754 :floatingpoint :constants :signbit/;
 
-sub core_abs($) { CORE::abs(shift) }
-
 my @tests = ();
-#            [CONSTANT           , 'NAME               ', negate()           , absolute()         , CORE::abs()        ];
-push @tests, [POS_ZERO           , 'POS_ZERO           ', NEG_ZERO           , POS_ZERO           , POS_ZERO           ];
-push @tests, [POS_DENORM_SMALLEST, 'POS_DENORM_SMALLEST', NEG_DENORM_SMALLEST, POS_DENORM_SMALLEST, POS_DENORM_SMALLEST];
-push @tests, [POS_DENORM_BIGGEST , 'POS_DENORM_BIGGEST ', NEG_DENORM_BIGGEST , POS_DENORM_BIGGEST , POS_DENORM_BIGGEST ];
-push @tests, [POS_NORM_SMALLEST  , 'POS_NORM_SMALLEST  ', NEG_NORM_SMALLEST  , POS_NORM_SMALLEST  , POS_NORM_SMALLEST  ];
-push @tests, [POS_NORM_BIGGEST   , 'POS_NORM_BIGGEST   ', NEG_NORM_BIGGEST   , POS_NORM_BIGGEST   , POS_NORM_BIGGEST   ];
-push @tests, [POS_INF            , 'POS_INF            ', NEG_INF            , POS_INF            , POS_INF            ];
-push @tests, [POS_SNAN_FIRST     , 'POS_SNAN_FIRST     ', NEG_SNAN_FIRST     , POS_SNAN_FIRST     , POS_SNAN_FIRST     ];
-push @tests, [POS_SNAN_LAST      , 'POS_SNAN_LAST      ', NEG_SNAN_LAST      , POS_SNAN_LAST      , POS_SNAN_LAST      ];
-push @tests, [POS_IND            , 'POS_IND            ', NEG_IND            , POS_IND            , POS_IND            ];
-push @tests, [POS_QNAN_FIRST     , 'POS_QNAN_FIRST     ', NEG_QNAN_FIRST     , POS_QNAN_FIRST     , POS_QNAN_FIRST     ];
-push @tests, [POS_QNAN_LAST      , 'POS_QNAN_LAST      ', NEG_QNAN_LAST      , POS_QNAN_LAST      , POS_QNAN_LAST      ];
+#            [CONSTANT           , 'NAME               ', negate()           , abs()         	  ];
+push @tests, [POS_ZERO           , 'POS_ZERO           ', NEG_ZERO           , POS_ZERO           ];
+push @tests, [POS_DENORM_SMALLEST, 'POS_DENORM_SMALLEST', NEG_DENORM_SMALLEST, POS_DENORM_SMALLEST];
+push @tests, [POS_DENORM_BIGGEST , 'POS_DENORM_BIGGEST ', NEG_DENORM_BIGGEST , POS_DENORM_BIGGEST ];
+push @tests, [POS_NORM_SMALLEST  , 'POS_NORM_SMALLEST  ', NEG_NORM_SMALLEST  , POS_NORM_SMALLEST  ];
+push @tests, [POS_NORM_BIGGEST   , 'POS_NORM_BIGGEST   ', NEG_NORM_BIGGEST   , POS_NORM_BIGGEST   ];
+push @tests, [POS_INF            , 'POS_INF            ', NEG_INF            , POS_INF            ];
+push @tests, [POS_SNAN_FIRST     , 'POS_SNAN_FIRST     ', NEG_SNAN_FIRST     , POS_SNAN_FIRST     ];
+push @tests, [POS_SNAN_LAST      , 'POS_SNAN_LAST      ', NEG_SNAN_LAST      , POS_SNAN_LAST      ];
+push @tests, [POS_IND            , 'POS_IND            ', NEG_IND            , POS_IND            ];
+push @tests, [POS_QNAN_FIRST     , 'POS_QNAN_FIRST     ', NEG_QNAN_FIRST     , POS_QNAN_FIRST     ];
+push @tests, [POS_QNAN_LAST      , 'POS_QNAN_LAST      ', NEG_QNAN_LAST      , POS_QNAN_LAST      ];
 
-push @tests, [NEG_ZERO           , 'NEG_ZERO           ', POS_ZERO           , POS_ZERO           , POS_ZERO           ];
-push @tests, [NEG_DENORM_SMALLEST, 'NEG_DENORM_SMALLEST', POS_DENORM_SMALLEST, POS_DENORM_SMALLEST, POS_DENORM_SMALLEST];
-push @tests, [NEG_DENORM_BIGGEST , 'NEG_DENORM_BIGGEST ', POS_DENORM_BIGGEST , POS_DENORM_BIGGEST , POS_DENORM_BIGGEST ];
-push @tests, [NEG_NORM_SMALLEST  , 'NEG_NORM_SMALLEST  ', POS_NORM_SMALLEST  , POS_NORM_SMALLEST  , POS_NORM_SMALLEST  ];
-push @tests, [NEG_NORM_BIGGEST   , 'NEG_NORM_BIGGEST   ', POS_NORM_BIGGEST   , POS_NORM_BIGGEST   , POS_NORM_BIGGEST   ];
-push @tests, [NEG_INF            , 'NEG_INF            ', POS_INF            , POS_INF            , POS_INF            ];
-push @tests, [NEG_SNAN_FIRST     , 'NEG_SNAN_FIRST     ', POS_SNAN_FIRST     , POS_SNAN_FIRST     , POS_SNAN_FIRST     ];
-push @tests, [NEG_SNAN_LAST      , 'NEG_SNAN_LAST      ', POS_SNAN_LAST      , POS_SNAN_LAST      , POS_SNAN_LAST      ];
-push @tests, [NEG_IND            , 'NEG_IND            ', POS_IND            , POS_IND            , POS_IND            ];
-push @tests, [NEG_QNAN_FIRST     , 'NEG_QNAN_FIRST     ', POS_QNAN_FIRST     , POS_QNAN_FIRST     , POS_QNAN_FIRST     ];
-push @tests, [NEG_QNAN_LAST      , 'NEG_QNAN_LAST      ', POS_QNAN_LAST      , POS_QNAN_LAST      , POS_QNAN_LAST      ];
+push @tests, [NEG_ZERO           , 'NEG_ZERO           ', POS_ZERO           , POS_ZERO           ];
+push @tests, [NEG_DENORM_SMALLEST, 'NEG_DENORM_SMALLEST', POS_DENORM_SMALLEST, POS_DENORM_SMALLEST];
+push @tests, [NEG_DENORM_BIGGEST , 'NEG_DENORM_BIGGEST ', POS_DENORM_BIGGEST , POS_DENORM_BIGGEST ];
+push @tests, [NEG_NORM_SMALLEST  , 'NEG_NORM_SMALLEST  ', POS_NORM_SMALLEST  , POS_NORM_SMALLEST  ];
+push @tests, [NEG_NORM_BIGGEST   , 'NEG_NORM_BIGGEST   ', POS_NORM_BIGGEST   , POS_NORM_BIGGEST   ];
+push @tests, [NEG_INF            , 'NEG_INF            ', POS_INF            , POS_INF            ];
+push @tests, [NEG_SNAN_FIRST     , 'NEG_SNAN_FIRST     ', POS_SNAN_FIRST     , POS_SNAN_FIRST     ];
+push @tests, [NEG_SNAN_LAST      , 'NEG_SNAN_LAST      ', POS_SNAN_LAST      , POS_SNAN_LAST      ];
+push @tests, [NEG_IND            , 'NEG_IND            ', POS_IND            , POS_IND            ];
+push @tests, [NEG_QNAN_FIRST     , 'NEG_QNAN_FIRST     ', POS_QNAN_FIRST     , POS_QNAN_FIRST     ];
+push @tests, [NEG_QNAN_LAST      , 'NEG_QNAN_LAST      ', POS_QNAN_LAST      , POS_QNAN_LAST      ];
 
-my @flist = qw(negate absolute core_abs);
-plan tests => scalar(@tests) * (scalar(@flist)+1)*2;
-
-my $isCoreAbsWrongForNegNaN = isCoreAbsWrongForNegNaN();
+my @flist = qw(negate abs);
+plan tests => scalar(@tests) * (scalar(@flist))*2;
 
 foreach my $t ( @tests ) {
     my ($c, $name, @x) = @$t;
     my $mi = (@flist >= @x) ? $#flist : $#x;
-    my $bool = $isCoreAbsWrongForNegNaN && ($name =~ /^NEG_[QS]NAN/i) || 0;
-        # TODO = v0.013_008 negate(NEG_IND) is confirmed on perl v5.16.0:
-        #   either debug or determine to just skip it on NEG_IND, too.
     foreach my $i ( 0 .. $mi ) {
         my $fn = $flist[$i];
         my $xi = $x[$i];
         my $f = \&{$fn};
-        SKIP: {
-            skip sprintf('CORE::abs() gives wrong value for abs(-NaN): '.$fn), 2 if $bool && ($fn eq 'core_abs');
-            is( ($f->($c)), ($xi), sprintf('%-20.20s(%-20.20s)', $fn, $name ) );
-            is( to_hex_floatingpoint($f->($c)), to_hex_floatingpoint($xi), sprintf('%-20.20s(%-20.20s)', $fn, $name ) );
-        }
+		is( ($f->($c)), ($xi), sprintf('%-20.20s(%-20.20s)', $fn, $name ) );
+		is( to_hex_floatingpoint($f->($c)), to_hex_floatingpoint($xi), sprintf('%-20.20s(%-20.20s)', $fn, $name ) );
     }
-    SKIP: {
-        skip sprintf('CORE::abs() gives wrong value for abs(-NaN): absolute vs CORE::abs'), 2 if $bool;
-        is( (absolute($c)), (core_abs($c)), sprintf('%-20.20s(%-20.20s) for CORE::abs(x) vs Data::IEEE754::Tools::absolute(x)', 'compare', $name) );
-        is( to_hex_floatingpoint(absolute($c)), to_hex_floatingpoint(core_abs($c)), sprintf('%-20.20s(%-20.20s) for CORE::abs(x) vs Data::IEEE754::Tools::absolute(x)', 'compare', $name) );
-    }
-}
-
-if( $isCoreAbsWrongForNegNaN ) {
-    # set the environment variable to a TRUE value to see the extra proof
-    if( exists $ENV{PROVE_CORE_ABS_WRONG} && $ENV{PROVE_CORE_ABS_WRONG} ) {
-        foreach my $c ( qw(NEG_QNAN_LAST POS_QNAN_LAST NEG_INF POS_INF) ) {
-    	    my $f = \&{$c};
-            my $x = $f->();
-            my $y = abs($x);
-            diag("\n");
-            foreach($x,$y) { diag( join "\t", $c,$_,isSignMinus($_),hexstr754_from_double($_)); };
-        }
-    }
-
-    diag( "\n" );
-    diag( "\n" );
-    diag( "*"x80 );
-    diag( 'WARNING: CORE::abs() gives wrong value for negative NaN values:');
-    diag( '         It should clear the sign bit, but it does not.');
-    diag( '         If this matters to you, use Data::IEEE754::Tools::absolute()');
-    diag( '         instead of CORE::abs() for computing the absolute value of a');
-    diag( '         floating-point that might be a negative NaN');
-    diag( "*"x80 );
-    diag( "\n" );
-    diag( "\n" );
 }
 
 exit;

--- a/t/10-copysign.t
+++ b/t/10-copysign.t
@@ -44,9 +44,11 @@ foreach my $x (@constants) {
 
         my $z = copySign($x, $y);
         my $zsign = isSignMinus($z);
+		
+		my $pre = sprintf('copySign(%-25.25s,%-25.25s): ', to_hex_floatingpoint($x), to_hex_floatingpoint($y));
 
-        is( $zsign , $ysign , sprintf('copySign(%-25.25s,%-25.25s): sign compare', to_hex_floatingpoint($x), to_hex_floatingpoint($y)) );
-        is( absolute($z), absolute($x), sprintf('copySign(%-25.25s,%-25.25s): abs compare', to_hex_floatingpoint($x), to_hex_floatingpoint($y)) );
+        is( $zsign , $ysign , $pre . 'sign compare' );
+        is( to_hex_floatingpoint(abs($z)), to_hex_floatingpoint(abs($x)), $pre . 'abs compare' );
     }
 }
 


### PR DESCRIPTION
    - v0.013_008: Devel::Cover showed SKIP was too aggressive in t\09 and t\10, so never tested 
		negate in v0.013_007.
        + FIXED BUG: t\09-signbit: while verifying test coverage in v0.013_008, discovered
          that signbit test was never testing negate, because the SKIP was too aggressive;
          once I de-aggressified the SKIP, finding more failures.
        + it looks like NEG_IND is not properly sign-changed to POS_IND, either... need to
          investigate further on multiple systems
		+ Determined that it's pointless to keep trying to make CORE::abs() pass the tests.
		  Rename Data::IEEE754::Tools::absolute() to ...::abs(), and stop testing the 
		  CORE::abs().  Just make a note that exporting abs or :signbit will override the
		  builtin behavior, and explain how to still access CORE::abs().
		+ remove isCoreAbsWrongForNegNaN(), since apparently Perl itself is the culprit, not
		  certain implementations.  (The auto-stringification of NaN was sometimes not 
		  distinguishing the sign bits.)
	    + t\10-copysign: switch to the to_hex_floatingpoint() for comparing abs($x) to abs($z),
		  to avoid the same display bug that masked the CORE::abs() bug for 5.8.5 and 5.24.0.
